### PR TITLE
Phrase fuzzy matcher para EPoF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# files
+/*.csv
+/*.odt
+/results/*.csv

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ def show_menu():
             print("Debe ingresar una de las opciones listadas.")
             print_menu()
 
-        # TODO actualizar menú en base a parámetros que se agregaron
+        # TODO actualizar menú en base a parámetros que se agregaron, ver si cabe la posibilidad de que lo usen asi
         if int(user_input) == 1:
             origin_path = input(
                 "Ingrese el path completo (nombre del archivo incluido) del documento a anonimizar y presione la tecla enter: \n"

--- a/model_utils.py
+++ b/model_utils.py
@@ -5,6 +5,7 @@ from spacy.tokens import Span
 from spacy.language import Language
 from pipeline_components.entity_ruler import ruler_patterns
 from pipeline_components.entity_custom import entity_custom
+from pipeline_components.epof_phrase_matcher import EpofPhraseMatcher
 
 EXCLUDED_ENTS = ["MISC", "ORG"]
 
@@ -19,6 +20,7 @@ class Nlp:
         ruler = self.nlp.add_pipe("entity_ruler", config={"overwrite_ents": True})
         ruler.add_patterns(ruler_patterns)
 
+        self.nlp.add_pipe("epof_phrase_matcher")
         self.nlp.add_pipe("entity_custom")
 
     def generate_doc(self, text):
@@ -81,6 +83,7 @@ def replace_tokens_with_labels(doc, color_entities):
 
 def anonymize_text(nlp, text, color_entities):
     doc = nlp.generate_doc(text)
+    # FIXME no detecta algunas cosas en mayusculas, ver feedback
     # found_texts = find_ent_ocurrencies_in_upper_text(doc.text, doc.ents)
 
     anonymized_text = replace_tokens_with_labels(doc, color_entities)

--- a/pipeline_components/entity_custom.py
+++ b/pipeline_components/entity_custom.py
@@ -56,6 +56,7 @@ place_first_left_nbors = [
     "distrito",
     "barrio",
 ]
+
 place_second_left_nbors = [
     "localidad",
     "ciudad",
@@ -318,15 +319,30 @@ def is_matricula(token):
     )
 
 
+# def is_epof(token):
+#     if not token.is_stop and len(token.text) > 2:
+#         # any_part_is_epof = any([enfermedad for enfermedad in lista_de_enfermedades if token.lower_ in enfermedad.lower().split()])
+#         found_epof = [enfermedad for enfermedad in lista_de_enfermedades if token.lower_ in enfermedad.lower().split()]
+#         if len(found_epof):
+#             print(f"\ntoken: {token.lower_} - found: {found_epof}")
+#             # import pdb; pdb.set_trace()
+#             #TODO deberia chequear si es alguna de las que encontró en base a la posición del token en las epof encontradas
+
+#         return (
+#                 token.lower_ in lista_de_enfermedades
+#                 or token.nbor(-1).lower_ in lista_de_enfermedades
+#                 or token.nbor(-2).lower_ in lista_de_enfermedades
+#                 or token.nbor(-3).lower_ in lista_de_enfermedades
+#             )
+#     return False
+
+
 @Language.component("entity_custom")
 def entity_custom(doc):
     new_ents = []
 
     def add_span(start, end, label):
         new_ents.append(Span(doc, start, end, label=label))
-
-    # TODO entity custom para:
-    # EPoF, ver nbors del archivo de epof (TOKEN)
 
     for token in doc:
         # print(f"token_ {token}")
@@ -342,6 +358,9 @@ def entity_custom(doc):
             add_span(token.i - left_extra_tokens, token.i + 1, "DIRECCION")
         if not is_from_first_tokens(token.i) and is_matricula(token):
             add_span(token.i - 1, token.i + 1, "MATRICULA")
+        # if not is_from_first_tokens(token.i) and is_epof(token):
+        #     print(f"is_epof token: {token}")
+        #     add_span(token.i - 1, token.i + 1, "EPOF")
 
     # print(f"\ndoc.ents: {doc.ents}")
     for i, ent in enumerate(doc.ents):

--- a/pipeline_components/entity_custom.py
+++ b/pipeline_components/entity_custom.py
@@ -301,6 +301,23 @@ def is_doctor_token(token):
     )
 
 
+def is_matricula(token):
+    splitted_token = token.text.split(".")
+    any_part_is_matricula = False
+    if token.like_num or splitted_token[0] != token.text:
+        any_part_is_matricula = any([part for part in splitted_token if part.lower() in matriculas])
+
+    return (
+        token.like_num
+        and (
+            token.nbor(-1).lower_ in matriculas
+            or token.nbor(-2).lower_ in matriculas
+            or token.nbor(-3).lower_ in matriculas
+        )
+        or any_part_is_matricula
+    )
+
+
 @Language.component("entity_custom")
 def entity_custom(doc):
     new_ents = []
@@ -309,7 +326,6 @@ def entity_custom(doc):
         new_ents.append(Span(doc, start, end, label=label))
 
     # TODO entity custom para:
-    # MATRICULA, ver nbors del archivo de matriculas (TOKEN)
     # EPoF, ver nbors del archivo de epof (TOKEN)
 
     for token in doc:
@@ -324,6 +340,8 @@ def entity_custom(doc):
         if not is_from_first_tokens(token.i) and is_address_token_from_number(token):
             left_extra_tokens = get_aditional_left_tokens_for_address_token(token)
             add_span(token.i - left_extra_tokens, token.i + 1, "DIRECCION")
+        if not is_from_first_tokens(token.i) and is_matricula(token):
+            add_span(token.i - 1, token.i + 1, "MATRICULA")
 
     # print(f"\ndoc.ents: {doc.ents}")
     for i, ent in enumerate(doc.ents):

--- a/pipeline_components/epof_phrase_matcher.py
+++ b/pipeline_components/epof_phrase_matcher.py
@@ -1,12 +1,13 @@
 import re
 from utils import get_text_from_file
-from rapidfuzz import process, fuzz
+from rapidfuzz import fuzz
 from spacy.matcher import PhraseMatcher
 from spacy.tokens import Span, Doc
 from spacy.util import filter_spans
 from spacy.language import Language
 
 lista_de_enfermedades = get_text_from_file("./data/", "epof.csv", 0, False)
+MATCH_PERCENTAGE = 92  # when finding matches for epof, it will keep matches over this percentage  of matching
 
 
 @Language.factory("epof_phrase_matcher")
@@ -22,27 +23,22 @@ class EpofPhraseMatcher:
 
     def __call__(self, doc: Doc) -> Doc:
         matches = self.matcher(doc)
-        new_ents = []
 
-        print(f"matches: {matches}")
-        # TODO qué pasa cuando no encuentra nada?
-
-        if len(matches):
+        if matches:
+            # using PhraseMatcher from Spacy
             match = matches[0]
-            print("Matched based on lowercase token text:", match[0], doc[match[-2] : match[-1]])
-            new_ents.append(Span(doc, match[-2], match[-1], label="EPOF"))
+            start = match[-2]
+            end = match[-1]
         else:
+            # using FuzzyWuzzy to find matches
             tokens = [token.text for token in doc]
-            match = fuzzy_matcher(lista_de_enfermedades, tokens, 92)
-            print("Matched based on lowercase token text:", match[0], doc[match[-2] : match[-1] + 1])
-            new_ents.append(Span(doc, match[-2], match[-1] + 1, label="EPOF"))
+            match = fuzzy_matcher(lista_de_enfermedades, tokens, MATCH_PERCENTAGE)
+            if match:
+                start = match[-2]
+                end = match[-1] + 1
 
-            # for match_id, epof, start, end in matches:
-            #   print("Matched based on lowercase token text:", doc[start:end+1])
-            #   new_ents.append(Span(doc, start, end+1, label="EPOF"))
-
-        if new_ents:
-            doc.ents = filter_spans(new_ents + list(doc.ents))
+        if match:
+            doc.ents = filter_spans([Span(doc, start, end, label="EPOF")] + list(doc.ents))
 
         return doc
 
@@ -64,4 +60,4 @@ def fuzzy_matcher(features, tokens, match=None):
                 if fuzz.ratio(matched_phrase, feature.lower()) > match:
                     matches.append([matched_phrase, feature, i, j])
 
-    return matches[0]
+    return matches[0] if len(matches) else matches

--- a/pipeline_components/epof_phrase_matcher.py
+++ b/pipeline_components/epof_phrase_matcher.py
@@ -1,0 +1,39 @@
+from utils import get_text_from_file
+from rapidfuzz import process
+from spacy.matcher import PhraseMatcher
+from spacy.tokens import Span, Doc
+from spacy.util import filter_spans
+from spacy.language import Language
+
+lista_de_enfermedades = get_text_from_file("./data/", "epof.csv", 0, False)
+
+
+@Language.factory("epof_phrase_matcher")
+def epof_phrase_matcher(nlp: Language, name: str):
+    return EpofPhraseMatcher(nlp)
+
+
+class EpofPhraseMatcher:
+    def __init__(self, nlp: Language):
+        self.matcher = PhraseMatcher(nlp.vocab, attr="LOWER")
+        patterns = list(nlp.tokenizer.pipe(lista_de_enfermedades))
+        self.matcher.add("epof_list", patterns)
+
+    def __call__(self, doc: Doc) -> Doc:
+        # FIXME si el texto escrito no coincide 100% con lo de la lista_de_enfermedades => no hay matches
+        # ver https://github.com/jackmen/PhuzzyMatcher/blob/master/notebooks/fuzzy_phrase_matcher.ipynb
+        matches = self.matcher(doc)
+
+        new_ents = []
+        for match_id, start, end in matches:
+            print("Matched based on lowercase token text:", doc[start:end])
+            # extracted = process.extract(doc[start:end].text, lista_de_enfermedades)
+            # print(f"all: {extracted}")
+            # one_extracted = process.extractOne(doc[start:end].text, lista_de_enfermedades)
+            # print(f"one: {one_extracted}")
+            new_ents.append(Span(doc, start, end, label="EPOF"))
+
+        if new_ents:
+            doc.ents = filter_spans(new_ents + list(doc.ents))
+
+        return doc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 appdirs==1.4.4
 argcomplete==1.10.0
+attrs==21.2.0
 beautifulsoup4==4.8.0
 blis==0.7.4
 catalogue==2.0.4
@@ -13,7 +14,6 @@ EbookLib==0.17.1
 es-core-news-lg @ https://github.com/explosion/spacy-models/releases/download/es_core_news_lg-3.0.0/es_core_news_lg-3.0.0-py3-none-any.whl
 extract-msg==0.23.1
 filelock==3.0.12
-fuzzywuzzy==0.18.0
 identify==2.2.11
 idna==2.10
 IMAPClient==2.1.0
@@ -38,6 +38,7 @@ python-Levenshtein==0.12.2
 python-pptx==0.6.18
 pytz==2021.1
 PyYAML==5.4.1
+rapidfuzz==1.4.1
 requests==2.25.1
 six==1.12.0
 smart-open==5.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,28 @@
+appdirs==1.4.4
 argcomplete==1.10.0
 beautifulsoup4==4.8.0
 blis==0.7.4
 catalogue==2.0.4
 certifi==2021.5.30
+cfgv==3.3.0
 chardet==3.0.4
 click==7.1.2
 cymem==2.0.5
+distlib==0.3.2
 EbookLib==0.17.1
-es-core-news-sm @ https://github.com/explosion/spacy-models/releases/download/es_core_news_sm-3.0.0/es_core_news_sm-3.0.0-py3-none-any.whl
+es-core-news-lg @ https://github.com/explosion/spacy-models/releases/download/es_core_news_lg-3.0.0/es_core_news_lg-3.0.0-py3-none-any.whl
 extract-msg==0.23.1
+filelock==3.0.12
+fuzzywuzzy==0.18.0
+identify==2.2.11
 idna==2.10
 IMAPClient==2.1.0
+importlib-metadata==4.6.1
 Jinja2==3.0.1
 lxml==4.6.3
 MarkupSafe==2.0.1
 murmurhash==1.0.5
+nodeenv==1.6.0
 numpy==1.21.0
 olefile==0.46
 packaging==20.9
@@ -26,8 +34,10 @@ preshed==3.0.5
 pycryptodome==3.10.1
 pydantic==1.7.4
 pyparsing==2.4.7
+python-Levenshtein==0.12.2
 python-pptx==0.6.18
 pytz==2021.1
+PyYAML==5.4.1
 requests==2.25.1
 six==1.12.0
 smart-open==5.1.0
@@ -38,11 +48,13 @@ spacy-legacy==3.0.6
 SpeechRecognition==3.8.1
 srsly==2.4.1
 thinc==8.0.6
+toml==0.10.2
 tqdm==4.61.1
 typer==0.3.2
 typing-extensions==3.10.0.0
 tzlocal==1.5.1
 urllib3==1.26.6
+virtualenv==20.4.7
 wasabi==0.8.2
 xlrd==1.2.0
 XlsxWriter==1.4.3


### PR DESCRIPTION
Se creó un phrase matcher usando FuzzyWuzzy para considerar typos o abreviaciones en Enfermedades Poco Frecuentes que aparezcan en las historias clínicas.

Para probarlo
- escribir algo simil historia clínica donde aparezca alguna de las EPoF descriptas en el archivo `/data/epof.csv`.
- mencionar una EPoF con algún typo o abreviación, por ejemplo: _ret_ en lugar de _retículo_.
- texto simil historia clínica en la que no haya ninguna EPoF


Recordar instalar los `requirements.txt` para probarlo